### PR TITLE
Simple Grayscale Support

### DIFF
--- a/src/decompress.py
+++ b/src/decompress.py
@@ -40,6 +40,7 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, GPU_FLAG, VERBOSE):
 	if not os.path.exists(OUTPUT_DIR): os.mkdir(OUTPUT_DIR)
 	
 	batch_size = 10
+	isRGB = True
 
 	weights_file = os.path.join(WEIGHTS_DIR, 'prednet_weights.hdf5')
 	json_file = os.path.join(WEIGHTS_DIR, 'prednet_model.json')
@@ -50,6 +51,9 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, GPU_FLAG, VERBOSE):
 	except FileNotFoundError as e:
 		print("ERROR:No such file or directory:", os.path.join(DATA_DIR, 'filename.txt'))
 		exit()
+
+	if (file_names[0].isdigit):
+		isRGB = bool(file_names.pop(0)) # Remove the RGB Status if there is one.
 
 	# Load trained model
 	try:
@@ -244,7 +248,7 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, GPU_FLAG, VERBOSE):
 
 	if VERBOSE: print ("finding_difference:{0}".format(elapsed_time) + "[sec]")
 
-	# 画像の出力
+	# 画像の出力 Image Output Process
 	decompress = X_hat_no_pad * 255
 	decompress = decompress - difference_first
 
@@ -264,5 +268,8 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, GPU_FLAG, VERBOSE):
 			tmp_np = decompress[i,j,:,:,:]
 			tmp_np = tmp_np.astype('uint8')
 			tmp_image = Image.fromarray(tmp_np)
-			tmp_image.save(os.path.join(OUTPUT_DIR, file_names[count]))
+			if isRGB: # Convert image back to grayscale when necessary.
+				tmp_image.save(os.path.join(OUTPUT_DIR, file_names[count]))
+			else:
+				tmp_image.convert("L").save(os.path.join(OUTPUT_DIR, file_names[count]))
 			count += 1

--- a/src/decompress.py
+++ b/src/decompress.py
@@ -52,7 +52,7 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, GPU_FLAG, VERBOSE):
 		print("ERROR:No such file or directory:", os.path.join(DATA_DIR, 'filename.txt'))
 		exit()
 
-	if (file_names[0].isdigit):
+	if (file_names[0].isdigit and len(file_names[0]) == 1):
 		isRGB = bool(file_names.pop(0)) # Remove the RGB Status if there is one.
 
 	# Load trained model

--- a/src/train_data_create.py
+++ b/src/train_data_create.py
@@ -37,6 +37,7 @@ def process_data(DATA_DIR, OUTPUT_DIR):
         for split in splits:
             folders_list = []
             for folder in splits[split]:
+                print(f"currently handling <{folder}>")
                 im_dir = os.path.join(DATA_DIR, folder)
                 files = list(os.walk(im_dir, topdown=False))[-1][-1]
                 folders_list += [os.path.join(im_dir, files[0])]
@@ -52,7 +53,7 @@ def process_data(DATA_DIR, OUTPUT_DIR):
         print("ERROR: Contains non-image files or inappropriate folders.")
         exit()
     except IndexError:
-        print("ERROR: Contains non-image files or inappropriate folders.")
+        print("ERROR: Contains non-image files or inappropriate folders. <<Index Error>>")
         exit()
     except UnidentifiedImageError:
         print("ERROR: Contains non-image files or inappropriate folders.")
@@ -75,7 +76,7 @@ def process_data(DATA_DIR, OUTPUT_DIR):
             X = np.zeros((len(im_list),) + desired_im_sz + (3,), np.uint8)
 
             for i, im_file in enumerate(im_list):
-                im = np.array(Image.open(im_file))
+                im = np.array(Image.open(im_file).convert('RGB'))
                 X[i, :im.shape[0], :im.shape[1]] = im
 
             hkl.dump(X, os.path.join(OUTPUT_DIR, 'X_' + split + '.hkl'))
@@ -96,8 +97,8 @@ def padding_shape(height, width):
     padding_width = padding_size(width)
     padding_shape_result = (padding_height, padding_width)
 
-    print('Before Padding：height:', height, ' width:', width)
-    print('After Padding ：height:', padding_height, ' width:', padding_width)
+    print('Before Padding: height:', height, ' width:', width)
+    print('After Padding: height:', padding_height, ' width:', padding_width)
 
     return padding_shape_result
 

--- a/src/train_data_create.py
+++ b/src/train_data_create.py
@@ -54,6 +54,13 @@ def process_data(DATA_DIR, OUTPUT_DIR):
         exit()
     except IndexError:
         print("ERROR: Contains non-image files or inappropriate folders. <<Index Error>>")
+        # This error could be caused by input folder format, the following is the correct format:
+        # Input Folder:
+        # -> time progressive dataset 1
+        # -> -> images...
+        # -> time progressive dataset 2
+        # -> -> images...
+        # ...
         exit()
     except UnidentifiedImageError:
         print("ERROR: Contains non-image files or inappropriate folders.")


### PR DESCRIPTION
For the learning mechanism, added RGB conversion directly to generate 3 channel trained model for the grayscale dataset.
For compression mechanism check and store image channel to `filename.txt`, then convert input images to 3 channels when deemed necessary.
For the decompression mechanism, obtain dataset status from line 1 of `filename.txt`, then convert the image back to 1 channel grayscale if necessary.
Support previous compressed 3 channel files without status appended in filenames by setting `isRGB` to true on `filename.txt` without image status.

*This is only a temporary fix for grayscale support as it only converts the grayscale input images to RGB, which may not be the most effective way of training a model that is meant for 3-channel RGB images.
