### PR TITLE
Bug fix in error bound in rel and absrel mode

### DIFF
--- a/src/compress.py
+++ b/src/compress.py
@@ -28,15 +28,13 @@ def error_bound(origine, diff, mode, value, GPU_FLAG, xp):
 	if mode == "abs":
 		E = xp.abs(value[0])
 	elif mode == "rel":
-		diff_abs = xp.abs(Df)
-		diff_max = diff_abs.max()
-		diff_min = diff_abs.min()
+		diff_max = Bf.max()
+		diff_min = Bf.min()
 		E = (diff_max - diff_min) * value[0]
 	elif mode == "absrel":
 		if value[1] == 0 : return diff
-		diff_abs = xp.abs(Df)
-		diff_max = diff_abs.max()
-		diff_min = diff_abs.min()
+		diff_max = Bf.max()
+		diff_min = Bf.min()
 		abs_value = xp.abs(value[0])
 		rel_value = (diff_max - diff_min) * value[1]
 		if abs_value < rel_value:
@@ -45,7 +43,7 @@ def error_bound(origine, diff, mode, value, GPU_FLAG, xp):
 			E = rel_value
 	elif mode == "pwrel":
 		E = Bf * value[0] # Error abs
-	
+
 	Du = Df + E # Du: Upper error bound
 	Dl = Df - E # Dl: Lower error bound
 
@@ -53,12 +51,12 @@ def error_bound(origine, diff, mode, value, GPU_FLAG, xp):
 		Df = xp.asnumpy(Df)
 		Du = xp.asnumpy(Du)
 		Dl = xp.asnumpy(Dl)
-	
+
 	u = float(np.inf) # Temp upper error bound
 	l = -u # Temp lower error bound
 	head = 0
 	for i in range(len(Df)):
-		# if accumulated product(intersect) set becomes empty, 
+		# if accumulated product(intersect) set becomes empty,
 		if min((u, Du[i])) - max((l, Dl[i])) < 0.0: #
 			Df[head:i] = (u + l)/2 # compute a median [l, u]
 			u = float(np.inf) # reinit
@@ -75,7 +73,7 @@ def error_bound(origine, diff, mode, value, GPU_FLAG, xp):
 def finding_difference(arr):
     arr_f = arr.flatten()
     arr_f[1:] = arr_f[:-1] - arr_f[1:]
-		
+
     return arr_f.reshape(arr.shape)
 
 
@@ -88,7 +86,7 @@ def replacing_based_on_frequency(arr, table, xp):
 
 	for idx, num in enumerate(table):
 		result = xp.where(result == num, idx, result)
-	
+
 	return result
 
 
@@ -101,7 +99,7 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, PREPROCESS, WINDOW_SIZE, THRESHOLD, M
 	if len(file_paths) == 0:
 		print("ERROR:", DATA_DIR, "is an empty or non-existent directory")
 		exit()
-	
+
 	try:
 		origine_img = np.array(Image.open(file_paths[0]))
 		origine_img = origine_img[np.newaxis, np.newaxis, :, :, :]
@@ -120,11 +118,11 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, PREPROCESS, WINDOW_SIZE, THRESHOLD, M
 	except UnidentifiedImageError as e:
 		print(DATA_DIR, "contains files or folders that are not images.")
 		exit()
-	
+
 	with open(os.path.join(OUTPUT_DIR, 'filename.txt'), 'w', encoding='UTF-8') as f:
 		for file_name in files:
 			f.write("%s\n" % file_name)
-	
+
 	X_test = origine_img.astype(np.float32) /255
 
 	batch_size = 10
@@ -161,7 +159,7 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, PREPROCESS, WINDOW_SIZE, THRESHOLD, M
 	inputs = Input(shape=tuple(input_shape))
 	predictions = test_prednet(inputs)
 	test_model = Model(inputs=inputs, outputs=predictions)
-	
+
 	# 推論用に元画像にパディング
 	X_test_pad = data_padding(X_test)
 
@@ -218,7 +216,7 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, PREPROCESS, WINDOW_SIZE, THRESHOLD, M
 
 		X_hat_predict_one = X_hat[0, 1]
 		X_hat_predict_one = X_hat_predict_one[np.newaxis, np.newaxis, :, :, :]
-		
+
 		X_test_origine_one = origine_img[0, idx]
 		X_test_origine_one = X_test_origine_one[np.newaxis, np.newaxis, :, :, :]
 
@@ -231,11 +229,11 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, PREPROCESS, WINDOW_SIZE, THRESHOLD, M
 		else:
 			predict_stack_np = np.hstack([predict_stack_np, X_hat_predict_one])
 			origine_stack_np = np.hstack([origine_stack_np, X_test_origine_one])
-		
+
 		if idx >= key_idx:
 			stop_point = np.mean( (X_test_pad[:, key_idx:idx+1] - predict_stack_np[:, 1:])**2 )
 			if VERBOSE: print("MSE:", stop_point)
-		
+
 		if (THRESHOLD != None and stop_point > THRESHOLD) or (WINDOW_SIZE != None and (idx - PREPROCESS) % WINDOW_SIZE == 0):
 			if VERBOSE: print("move key point")
 			origine_result = origine_stack_np[:, :-1]
@@ -307,14 +305,14 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, PREPROCESS, WINDOW_SIZE, THRESHOLD, M
 				start = time.time()
 				for channel in range(3):
 					difference[:,img_num, :, :, channel] = error_bound(X_test_1[:,img_num, :, :, channel], difference[:,img_num, :, :, channel], MODE, BOUND_VALUE, GPU_FLAG, xp)
-				
+
 				elapsed_time = time.time() - start
 				error_bound_time = error_bound_time + elapsed_time
-				
+
 		difference_list.append(difference)
-	
+
 	if VERBOSE: print ("error_bound:{0}".format(error_bound_time) + "[sec]")
-	
+
 	# 推論結果をまとめる　GPU&pwrelの場合はこの段階でcupyに切り替わる
 	difference_model = difference_list[0]
 	for X_hat_np in difference_list[1:]:
@@ -388,5 +386,4 @@ def run(WEIGHTS_DIR, DATA_DIR, OUTPUT_DIR, PREPROCESS, WINDOW_SIZE, THRESHOLD, M
 	data=zstd.compress(result_difference_str, 9)
 	with open(os.path.join(OUTPUT_DIR, "entropy.dat"), mode='wb') as f:
 		f.write(data)
-	
-	
+


### PR DESCRIPTION
resolve #21 

# 概要
+ compress.pyのerror_bound関数(mode: rel, absrel)の修正
修正前：誤差から最大値と最小値を計算し誤差範囲を算出
修正後：元データの最大値と最小値から誤差範囲を算出

# テスト
+ 修正前後で解凍画像を比較した所、GPUモードで効果が確認
------------
# Overview
+ Fixed function: error_bound (mode: rel, absrel) in compress.py.
Before revision : Calculate the maximum and minimum values from the error and calculate the error range.
After revision : Calculate the error range from the maximum and minimum values of the original data.

# test
+ Comparing the decompressed images before and after the correction, the effect is confirmed in GPU mode.